### PR TITLE
Specify conda channel for rdkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The `molecule_generation` package depends on `rdkit`, which has to be installed 
 ```bash
 conda create --name moler-env python=3.7
 conda activate moler-env
-conda install rdkit==2020.09.1.0
+conda install rdkit==2020.09.1.0 -c conda-forge
 ```
 
 Then, to install `molecule_generation`, simply run `pip install -e .` within the root folder.


### PR DESCRIPTION
RDKit installation instructions from `README.md` were incomplete, as the channel to find `rdkit` in was missing (thanks @sarahnlewis for noticing!). I'm adding the missing part of the command here.