### PR TITLE
Allow CI to be manually triggered

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   build-linux:


### PR DESCRIPTION
Add 'worflow_dispatch' to the list of triggers in `ci.yml` so that the workflow can be triggered manually.