### PR TITLE
Set up versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 
 # Package installation:
+.eggs/
 *.egg-info/
 
 # Model checkpoints:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+All notable changes to the project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2022-04-11
+
+This is the first public release, matching what was used for [the original paper](https://arxiv.org/abs/2103.03864).
+
+### Added
+- Full implementation of MoLeR as introduced in the paper
+- Reference implementation of CGVAE, not yet supported by the high-level model API
+
+[Unreleased]: https://github.com/microsoft/molecule-generation/compare/0.1.0...HEAD
+[0.1.0]: https://github.com/microsoft/molecule-generation/releases/tag/0.1.0

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(this_directory, "README.md"), encoding="utf-8") as f:
 
 setuptools.setup(
     name="molecule_generation",
-    version="0.0.0",
+    use_scm_version=True,
     license="MIT",
     author="Krzysztof Maziarz",
     author_email="krzysztof.maziarz@microsoft.com",
@@ -15,6 +15,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/microsoft/molecule-generation/",
+    setup_requires=["setuptools_scm"],
     python_requires="==3.7.*",
     install_requires=[
         "dpu-utils>=0.2.13",


### PR DESCRIPTION
This PR sets up automatic versioning using `setuptools_scm` which reads the version from git's tags, so that there is no need to manually update `setup.py`. Once this is merged, I will tag the resulting commit with a `0.1.0` tag to mark the initial public release.