### PR TITLE
Fix CLI by using VaeWrapper instead of ModelWrapper

### DIFF
--- a/molecule_generation/cli/encode.py
+++ b/molecule_generation/cli/encode.py
@@ -2,7 +2,7 @@
 import argparse
 import pickle
 
-from molecule_generation import ModelWrapper
+from molecule_generation import VaeWrapper
 from molecule_generation.utils.cli_utils import (
     get_model_loading_parser,
     setup_logging,
@@ -18,7 +18,7 @@ def save_smiles_embeddings(
 
     print(f"Read {len(smiles_list)} SMILES strings.")
 
-    with ModelWrapper(model_dir, **model_kwargs) as model:
+    with VaeWrapper(model_dir, **model_kwargs) as model:
         embeddings = model.encode(smiles_list)
 
     with open(output_path, "wb+") as f:

--- a/molecule_generation/cli/sample.py
+++ b/molecule_generation/cli/sample.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import argparse
 
-from molecule_generation import ModelWrapper
+from molecule_generation import VaeWrapper
 from molecule_generation.utils.cli_utils import (
     get_model_loading_parser,
     setup_logging,
@@ -10,7 +10,7 @@ from molecule_generation.utils.cli_utils import (
 
 
 def print_samples(model_dir: str, num_samples: int, **model_kwargs) -> None:
-    with ModelWrapper(model_dir, **model_kwargs) as model:
+    with VaeWrapper(model_dir, **model_kwargs) as model:
         samples = model.sample(num_samples)
 
     print("\n".join(samples))

--- a/molecule_generation/utils/moler_visualisation_utils.py
+++ b/molecule_generation/utils/moler_visualisation_utils.py
@@ -16,7 +16,7 @@ from molecule_generation.layers.moler_decoder import (
 )
 from molecule_generation.models.moler_vae import MoLeRVaeOutput
 from molecule_generation.utils.model_utils import load_vae_model_and_dataset
-from molecule_generation.wrapper import ModelWrapper
+from molecule_generation.wrapper import VaeWrapper
 
 
 class PropertyPredictionInformation(NamedTuple):
@@ -32,7 +32,7 @@ class AtomPredictionInformation(NamedTuple):
 
 class GraphGenerationVisualiser(ABC):
     def __init__(self, model_dir: str):
-        dataset, vae = load_vae_model_and_dataset(ModelWrapper._get_model_file(model_dir))
+        dataset, vae = load_vae_model_and_dataset(VaeWrapper._get_model_file(model_dir))
         self.dataset = dataset
         self.dataset.params[
             "trace_element_keep_prob"


### PR DESCRIPTION
After some of the refactoring done in #6, `ModelWrapper` is now an abstract base class that cannot be instantiated. This broke the CLI entry points, which were all still using `ModelWrapper` (thanks Tien Huynh for flagging!).

This PR is a quick fix of simply replacing `ModelWrapper` with `VaeWrapper`, which is the concrete wrapper class for `MoLeRVae`. There are two extensions that I'd defer to follow-up PRs in order to fix CLI quicker:
- We should have tests covering CLI itself so that we don't break it in the future.
- Some CLI endpoints (e.g. `sample`) could support `MoLeRGenerator`, but they won't if we use `VaeWrapper` and not `GeneratorWrapper`.