### PR TITLE
Constrain protobuf version to avoid a breaking release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Improved how the MoLeR visualisers handle node selection steps and fixed the "visualise from latents" mode ([#10](https://github.com/microsoft/molecule-generation/pull/10))
 
+### Fixed
+- Constrained the version of `protobuf` to avoid pulling in a breaking release ([#25](https://github.com/microsoft/molecule-generation/pull/25))
+
 ## [0.1.0] - 2022-04-11
 
 This is the first public release, matching what was used for [the original paper](https://arxiv.org/abs/2103.03864).

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setuptools.setup(
         "dpu-utils>=0.2.13",
         "more-itertools",
         "numpy==1.19.2",  # Pinned due to incompatibility with `tensorflow`.
+        "protobuf<4",  # Avoid the breaking 4.21.0 release.
         "scikit-learn>=0.24.1",
         "tensorflow==2.1.0",  # Pinned due to issues with `h5py`.
         "tf2_gnn>=2.13.0",


### PR DESCRIPTION
Recently a breaking version of `protobuf` was released, which broke many downstream libraries that didn't pin the version (see [this thread](https://github.com/protocolbuffers/protobuf/issues/10051)). Following these other libraries, in this PR I constrain the `protobuf` version to `<4`.