### PR TITLE
Enable encoding to also return log variance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `MoLeRGenerator`, which uses the MoLeR decoder (without the encoder) as an autoregressive policy ([#6](https://github.com/microsoft/molecule-generation/pull/6))
 - `load_model_from_directory`, which can load any model by automatically picking the right wrapper class (either `VaeWrapper` or `GeneratorWrapper`) ([#24](https://github.com/microsoft/molecule-generation/pull/24))
+- An option for `encode` to return not only the mean latent code but also the variance ([#26](https://github.com/microsoft/molecule-generation/pull/26))
 
 ### Changed
 - Improved how the MoLeR visualisers handle node selection steps and fixed the "visualise from latents" mode ([#10](https://github.com/microsoft/molecule-generation/pull/10))

--- a/molecule_generation/wrapper.py
+++ b/molecule_generation/wrapper.py
@@ -1,6 +1,6 @@
 import pathlib
 import random
-from typing import ContextManager, List, Optional, Union
+from typing import ContextManager, List, Optional, Tuple, Union
 
 import numpy as np
 import tensorflow as tf
@@ -91,16 +91,25 @@ class VaeWrapper(ModelWrapper):
         """
         return np.random.normal(size=(num_samples, self._latent_size)).astype(np.float32)
 
-    def encode(self, smiles_list: List[str]) -> List[np.ndarray]:
+    def encode(
+        self, smiles_list: List[str], include_log_variances: bool = False
+    ) -> Union[List[np.ndarray], List[Tuple[np.ndarray, np.ndarray]]]:
         """Encode input molecules to vectors in the latent space.
 
         Args:
-            smiles_list: List of molecules as SMILES
+            smiles_list: List of molecules as SMILES.
+            include_log_variances: Whether to also return log variances on the latent encodings.
 
         Returns:
-            List of latent vectors.
+            List of results. Each result is the mean latent encoding if `include_log_variances` is
+            `False`, and a pair containing the mean and the corresponding log variance otherwise.
         """
-        return self._inference_server.encode(smiles_list)
+        # Note: if we ever start being strict about type hints, we could properly express the
+        # relationship between `include_log_variances` and the return type using `@overload`.
+
+        return self._inference_server.encode(
+            smiles_list, include_log_variances=include_log_variances
+        )
 
     def decode(
         self,


### PR DESCRIPTION
When doing encoding in `MoLeRVae`, we currently only return the mean latent code, ignoring the variance. This is enough for many applications (e.g. optimization), but in certain cases knowing the entire distribution can be useful. In this PR, I add a flag that makes `encode` also return the variances.