### PR TITLE
Refactor and improve generation step tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Improved how the MoLeR visualisers handle node selection steps and fixed the "visualise from latents" mode ([#10](https://github.com/microsoft/molecule-generation/pull/10))
+- Refactored how MoLeR keeps track of generation steps during decoding and included partial molecules in the step info classes ([#27](https://github.com/microsoft/molecule-generation/pull/27))
 
 ### Fixed
 - Constrained the version of `protobuf` to avoid pulling in a breaking release ([#25](https://github.com/microsoft/molecule-generation/pull/25))

--- a/molecule_generation/test/layers/test_moler_decoder.py
+++ b/molecule_generation/test/layers/test_moler_decoder.py
@@ -1,69 +1,107 @@
 """Tests for the MoLeRDecoder class."""
 import pytest
 from collections import Counter
+from typing import Any, Dict, List
 
 import rdkit.Chem
 import tensorflow as tf
 
-from molecule_generation.layers.moler_decoder import MoLeRDecoder, MoLeRDecoderInput
 from molecule_generation.chem.atom_feature_utils import AtomTypeFeatureExtractor
 from molecule_generation.chem.motif_utils import MotifExtractionSettings, MotifVocabulary
+from molecule_generation.layers.moler_decoder import (
+    MoLeRDecoder,
+    MoLeRDecoderInput,
+    MoLeRDecoderState,
+)
+from molecule_generation.utils.moler_decoding_utils import DecoderSamplingMode
 
 
-@pytest.mark.parametrize("beam_size", [1, 4])
-@pytest.mark.parametrize("max_nodes_per_batch", [10, 1000])
-def test_returns_correct_number_of_states(beam_size: int, max_nodes_per_batch: int):
-    tf.random.set_seed(2)
+def decode_random_latents(
+    num_samples: int, decoder_param_overrides: Dict[str, Any], decode_kwargs: Dict[str, Any]
+) -> List[MoLeRDecoderState]:
+    tf.random.set_seed(0)
 
-    # Given:
     atom_type_featuriser = AtomTypeFeatureExtractor()
-    atom_type_featuriser.prepare_metadata(rdkit.Chem.Atom("C"))
+    for atom_type in ["C", "N", "O"]:
+        atom_type_featuriser.prepare_metadata(rdkit.Chem.Atom(atom_type))
     atom_type_featuriser.mark_metadata_initialised()
 
     params = MoLeRDecoder.get_default_params()
-    params["max_nodes_per_batch"] = max_nodes_per_batch
+    params.update(**decoder_param_overrides)
 
     decoder = MoLeRDecoder(
         params=params,
         atom_featurisers=[atom_type_featuriser],
-        index_to_node_type_map={0: "UNK", 1: "C", 2: "C1=CC=CC1N"},
+        index_to_node_type_map={0: "UNK", 1: "C", 2: "N", 3: "O", 4: "O=[N+][O-]", 5: "C1=CC=CC1N"},
         motif_vocabulary=MotifVocabulary(
-            vocabulary={"C1=CC=CC1N": 0},
+            vocabulary={"O=[N+][O-]": 0, "C1=CC=CC1N": 1},
             settings=MotifExtractionSettings(
-                min_frequency=None, min_num_atoms=None, cut_leaf_edges=True, max_vocab_size=None
+                min_frequency=None, min_num_atoms=3, cut_leaf_edges=True, max_vocab_size=2
             ),
         ),
     )
 
-    latent_size = 8
-    node_features = atom_type_featuriser.feature_width
-    edge_features = 3
+    # The latent dimension doesn't matter for correctness; hardcode it to something small.
+    latent_dim = 8
 
     decoder.build(
         MoLeRDecoderInput(
-            node_features=(None, node_features),
+            node_features=(None, atom_type_featuriser.feature_width),
             node_categorical_features=(None,),
             adjacency_lists=tuple((None, 2) for _ in range(4)),
             num_graphs_in_batch=(),
             graph_to_focus_node_map=(None,),
             node_to_graph_map=(None,),
-            input_molecule_representations=(None, latent_size),
+            input_molecule_representations=(None, latent_dim),
             graphs_requiring_node_choices=(None,),
             candidate_edges=(None, 2),
-            candidate_edge_features=(None, edge_features),
+            candidate_edge_features=(None, 3),
             candidate_attachment_points=(None,),
         )
     )
 
-    num_graphs = 2
-    decoder_states = decoder.decode(
-        graph_representations=tf.random.normal(shape=(num_graphs, latent_size)),
-        beam_size=beam_size,
+    # Use `SAMPLING` mode (instead of the default `GREEDY`) to cover more different execution paths.
+    return decoder.decode(
+        graph_representations=tf.random.normal(shape=(num_samples, latent_dim)),
+        max_num_steps=10,
+        sampling_mode=DecoderSamplingMode.SAMPLING,
+        **decode_kwargs,
     )
 
-    # Then:
-    assert len(decoder_states) == num_graphs * beam_size
+
+@pytest.mark.parametrize("beam_size", [1, 3])
+@pytest.mark.parametrize("max_nodes_per_batch", [10, 1000])
+def test_returns_correct_number_of_states(beam_size: int, max_nodes_per_batch: int):
+    num_samples = 2
+    decoder_states = decode_random_latents(
+        num_samples=num_samples,
+        decoder_param_overrides={"max_nodes_per_batch": max_nodes_per_batch},
+        decode_kwargs={"beam_size": beam_size},
+    )
+
+    assert len(decoder_states) == num_samples * beam_size
 
     id_counts = Counter([state.molecule_id for state in decoder_states])
-    for id in range(num_graphs):
+    for id in range(num_samples):
         assert id_counts[id] == beam_size
+
+
+@pytest.mark.parametrize("store_generation_traces", [False, True])
+def test_can_store_generation_traces(store_generation_traces: bool):
+    decoder_states = decode_random_latents(
+        num_samples=10,
+        decoder_param_overrides={},
+        decode_kwargs={"store_generation_traces": store_generation_traces},
+    )
+
+    for decoder_state in decoder_states:
+        if store_generation_traces:
+            assert decoder_state.generation_steps is not None
+
+            for step in decoder_state.generation_steps:
+                # Step metadata classes have a `molecule` field, which is initially set to `None`,
+                # and then filled in by the `MoLeRDecoderState` class. Let's make sure all molecules
+                # were actually filled in.
+                assert step.molecule is not None
+        else:
+            assert decoder_state.generation_steps is None


### PR DESCRIPTION
This PR contains two high-level changes:
- The generation step info during MoLeR's decoding was passed around in a somewhat convoluted way, by keeping three lists containing steps of different types (atom addition, bond addition, attachment point selection), aligned such that for each index only one of the lists contained an actual class, while the other ones contained `None`. I refactored this so that there is a single list with step info classes, which reduced the amount of bookkeeping needed.
- Even though the step info classes collect all sorts of useful information, the partial molecules were not explicitly kept around, and they are needed for running post-hoc analysis. One complication here is that most of the step information is available early on, while the molecule is constructed later by `MoLeRDecoderState`. I thus made the step info classes mutable, and set the `molecule` field when it's available. Since there's a risk of one code path not setting that field at all, I added a new test to cover this pitfall.