### PR TITLE
Add support for fine-tuning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Support for fine-tuning a pretrained model on new data ([#30](https://github.com/microsoft/molecule-generation/pull/30))
+
 ## [0.2.0] - 2022-07-01
 
 ### Added

--- a/molecule_generation/chem/molecule_dataset_utils.py
+++ b/molecule_generation/chem/molecule_dataset_utils.py
@@ -154,7 +154,7 @@ class FeaturisedData:
         len_valid_data: int,
         test_data: Iterable[Dict[str, Any]],
         len_test_data: int,
-        atom_feature_extractors: List[AtomFeatureExtractor],
+        atom_feature_extractors: Optional[List[AtomFeatureExtractor]] = None,
         featuriser_data: Optional[Iterable[Dict[str, Any]]] = None,
         len_featurizer_data: Optional[int] = None,
         motif_extraction_settings: Optional[MotifExtractionSettings] = None,
@@ -223,8 +223,8 @@ def featurise_smiles_datapoints(
     train_data: List[Dict[str, Any]],
     valid_data: List[Dict[str, Any]],
     test_data: List[Dict[str, Any]],
-    atom_feature_extractors: List[AtomFeatureExtractor],
-    temporary_save_directory: RichPath = None,
+    atom_feature_extractors: Optional[List[AtomFeatureExtractor]] = None,
+    temporary_save_directory: Optional[RichPath] = None,
     motif_extraction_settings: Optional[MotifExtractionSettings] = None,
     num_processes: int = 8,
     include_fingerprints: bool = False,
@@ -245,10 +245,11 @@ def featurise_smiles_datapoints(
         temporary_save_directory: an (optional) directory to cache intermediate results to
             reduce unnecessary recalculation. If used, should be manually cleared if any changes
             have been made to the _smiles_to_mols function.
+        motif_extraction_settings: settings to use for extracting the vocabulary.
         num_processes: number of parallel worker processes to use for processing.
 
     Returns:
-        A FeaturisedData tuple.
+        A `FeaturisedData` object.
     """
     tmp_train_path, tmp_test_path, tmp_valid_path = None, None, None
     if temporary_save_directory is not None:
@@ -488,7 +489,7 @@ def molecule_to_graph(
 
 def _lazy_smiles_to_mols(
     datapoints: Iterable[Dict[str, Any]],
-    save_path: RichPath = None,
+    save_path: Optional[RichPath] = None,
     num_processes: int = 8,
     include_fingerprints: bool = True,
     include_descriptors: bool = True,
@@ -525,7 +526,7 @@ def _lazy_smiles_to_mols(
 
 def smiles_to_mols(
     datapoints: List[Dict[str, Any]],
-    save_path: RichPath = None,
+    save_path: Optional[RichPath] = None,
     num_processes: int = 8,
     include_fingerprints: bool = True,
     include_descriptors: bool = True,


### PR DESCRIPTION
As discussed in #21, fine-tuning models was not fully supported, as preprocessing data for fine-tuning would need to know about atom featurisers and motif vocabulary built during pretraining, and there was no way to plug those in. I add support for this here, and explain how to perform fine-tuning in `README.md`.