### PR TITLE
Point to tensorflow website in case of installation issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ pip install molecule-generation
 Alternatively, running `pip install -e .` within the root folder installs the latest state of the code, including changes that were merged into `main` but not yet released.
 
 Note that in the instructions above we pinned the `rdkit` version, as this is the version the code has been tested with. However, our code is likely to work with other modern version of `rdkit` as well.
+Finally, if `tensorflow` installation doesn't work out-of-the-box for your particular system, you may need to refer to [the tensorflow website](https://www.tensorflow.org/install) for guidelines.
 
 A MoLeR checkpoint trained using the default hyperparameters is available [here](https://figshare.com/ndownloader/files/34642724). This file needs to be saved in a fresh folder `MODEL_DIR` (e.g., `/tmp/MoLeR_checkpoint`) and be renamed to have the `.pkl` ending (e.g., to `GNN_Edge_MLP_MoLeR__2022-02-24_07-16-23_best.pkl`). Then you can sample 10 molecules by running
 


### PR DESCRIPTION
As highlighted in #31, for some system versions installing tensorflow may not work out-of-the-box. This is not specific to `molecule_generation`, but it doesn't hurt to point to tensorflow's website in case such issues arise, so I'm adding a quick note in the README here.