### PR TITLE
Support modern versions of Python and tensorflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,25 +8,36 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-linux:
+  build:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7"]
+        include:
+          - python: "3.7.7"
+            tensorflow: "2.1.0"
+            numpy: "1.19.2"
+          - python: "3.9.13"
+            tensorflow: "2.9.1"
+            numpy: "1.23.1"
+    name: build (Python ${{ matrix.python }}, TF ${{ matrix.tensorflow }})
 
     steps:
     - uses: actions/checkout@v3
     - name: Add conda to system path
       run: |
         echo $CONDA/bin >> $GITHUB_PATH
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python ${{ matrix.python }}
       run: |
-        conda install python=${{ matrix.python-version }}
+        conda install python=${{ matrix.python }} -c conda-forge
+    - name: Set up tensorflow ${{ matrix.tensorflow }}
+      run: |
+        conda install tensorflow=${{ matrix.tensorflow }} -c conda-forge
     - name: Install dependencies
       run: |
         conda install rdkit==2020.09.1.0 -c conda-forge
         python -m pip install --upgrade pip
+        python -m pip install numpy==${{ matrix.numpy }}
         python -m pip install .
         python -m pip install black flake8 pytest
     - name: Lint with black

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Support for fine-tuning a pretrained model on new data ([#30](https://github.com/microsoft/molecule-generation/pull/30))
+- `__version__` attribute to make the package version easily accessible at runtime ([#35](https://github.com/microsoft/molecule-generation/pull/35))
+
+### Changed
+- Dropped the exact version requirements for `python` and `tensorflow` in order to support entire ranges of versions, including modern ones ([#35](https://github.com/microsoft/molecule-generation/pull/35))
 
 ### Removed
 - Unused `GraphMultitaskModel` which ended up in the open-source release by accident ([#34](https://github.com/microsoft/molecule-generation/pull/34))

--- a/README.md
+++ b/README.md
@@ -9,15 +9,16 @@ This repository contains training and inference code for the MoLeR model introdu
 
 ## Quick start
 
-The `molecule_generation` package depends on `rdkit`, which has to be installed separately. One simple approach is to do it via `conda`
+The `molecule_generation` package can be installed via `pip`, but it additionally depends on `rdkit` and (if one wants to use a GPU) on correctly setting up CUDA libraries. One approach to get both is through our minimalistic `conda` environment:
 
 ```bash
-conda create --name moler-env python=3.7
+conda env create -f environment.yml
 conda activate moler-env
-conda install rdkit==2020.09.1.0 -c conda-forge
 ```
 
-Then, to install the latest release of `molecule_generation`, simply run
+This environment pins the versions of `python`, `rdkit` and `tensorflow` for reproducibility, but `molecule_generation` is compatible with a range of versions of these dependencies.
+
+To then install the latest release of `molecule_generation`, simply run
 ```bash
 pip install molecule-generation
 ```

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,8 @@
+name: moler-env
+channels:
+  - rdkit
+  - conda-forge
+dependencies:
+  - python==3.9.13
+  - rdkit==2020.09.1.0
+  - tensorflow==2.9.1

--- a/molecule_generation/__init__.py
+++ b/molecule_generation/__init__.py
@@ -1,3 +1,4 @@
+from molecule_generation.version import __version__
 from molecule_generation.wrapper import (
     ModelWrapper,
     VaeWrapper,
@@ -5,4 +6,10 @@ from molecule_generation.wrapper import (
     load_model_from_directory,
 )
 
-__all__ = ["ModelWrapper", "VaeWrapper", "GeneratorWrapper", "load_model_from_directory"]
+__all__ = [
+    "__version__",
+    "ModelWrapper",
+    "VaeWrapper",
+    "GeneratorWrapper",
+    "load_model_from_directory",
+]

--- a/molecule_generation/layers/graph_property_predictor.py
+++ b/molecule_generation/layers/graph_property_predictor.py
@@ -40,7 +40,7 @@ class GraphPropertyPredictor(tf.keras.layers.Layer):
         property_stddev: Optional[float],
         **kwargs,
     ):
-        super().__init__(params, **kwargs)
+        super().__init__(**kwargs)
         self._params = params
         self._property_type = PropertyTaskType[property_type.upper()]
 

--- a/molecule_generation/version.py
+++ b/molecule_generation/version.py
@@ -1,0 +1,11 @@
+import sys
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
+
+try:
+    __version__ = metadata.version("molecule_generation")
+except Exception:
+    __version__ = None

--- a/setup.py
+++ b/setup.py
@@ -16,14 +16,14 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/microsoft/molecule-generation/",
     setup_requires=["setuptools_scm"],
-    python_requires="==3.7.*",
+    python_requires=">=3.7",
     install_requires=[
         "dpu-utils>=0.2.13",
         "more-itertools",
-        "numpy==1.19.2",  # Pinned due to incompatibility with `tensorflow`.
-        "protobuf<4",  # Avoid the breaking 4.21.0 release.
+        "numpy>=1.19.2",
+        "protobuf>=3.20,<4",  # Avoid the breaking 4.21.0 release.
         "scikit-learn>=0.24.1",
-        "tensorflow==2.1.0",  # Pinned due to issues with `h5py`.
+        "tensorflow>=2.1.0,<3",
         "tf2_gnn>=2.13.0",
     ],
     packages=setuptools.find_packages(),
@@ -34,6 +34,9 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
     ],
 )


### PR DESCRIPTION
This PR unpins the main dependencies, so that one can use various versions of Python and tensorflow. I quickly checked and things seem to work under modern versions, with the exception of one silly bug in CGVAE files that I had to fix. I also changed the CI buld so that it tests the code both under the old versions (to make sure they continue to work) and modern versions (Python 3.9, tf 2.9).