### PR TITLE
Python 3.8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository contains training and inference code for the MoLeR model introdu
 The `molecule_generation` package depends on `rdkit`, which has to be installed separately. One simple approach is to do it via `conda`
 
 ```bash
-conda create --name moler-env python=3.7
+conda create --name moler-env python=3.8
 conda activate moler-env
 conda install rdkit==2020.09.1.0 -c conda-forge
 ```

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/microsoft/molecule-generation/",
     setup_requires=["setuptools_scm"],
-    python_requires="==3.8.*",
+    python_requires=">=3.7.*,<3.9",
     install_requires=[
         "dpu-utils>=0.2.13",
         "more-itertools",

--- a/setup.py
+++ b/setup.py
@@ -16,14 +16,14 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/microsoft/molecule-generation/",
     setup_requires=["setuptools_scm"],
-    python_requires="==3.7.*",
+    python_requires="==3.8.*",
     install_requires=[
         "dpu-utils>=0.2.13",
         "more-itertools",
-        "numpy==1.19.2",  # Pinned due to incompatibility with `tensorflow`.
+        "numpy>=1.19.2",  # Pinned due to incompatibility with `tensorflow`.
         "protobuf<4",  # Avoid the breaking 4.21.0 release.
         "scikit-learn>=0.24.1",
-        "tensorflow==2.1.0",  # Pinned due to issues with `h5py`.
+        "tensorflow>=2.1.0",  # Pinned due to issues with `h5py`.
         "tf2_gnn>=2.13.0",
     ],
     packages=setuptools.find_packages(),


### PR DESCRIPTION
Since python 3.7 will reach EOL pretty soon, it would be great to support current python versions.
Also, keep in mind that your stringency in the `setup.py` (`python==3.7`) limits the usability for downstream package. Basically you're forcing everybody who wants to integrate your code to use python 3.7.

I adapted the setup, recreated the env and did not observe any issues. I evaluated the inference, not training and visualization.