### PR TITLE
Remove deprecated numpy types to make things work with numpy 1.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Reformatted the code with the newest `black` (version `23.1.0`) and pinned it in CI to avoid further unexpected updates ([#50](https://github.com/microsoft/molecule-generation/pull/50))
 
+### Fixed
+- Removed deprecated `numpy` types to make `molecule_generation` work with `numpy>=1.24.0` ([#49](https://github.com/microsoft/molecule-generation/pull/49))
+
 ## [0.3.0] - 2022-10-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ conda env create -f environment.yml
 conda activate moler-env
 ```
 
-This environment pins the versions of `python`, `rdkit` and `tensorflow` for reproducibility, but `molecule_generation` is compatible with a range of versions of these dependencies.
+This environment pins the versions of `python`, `rdkit` and `tensorflow` for reproducibility, but `molecule_generation` is compatible with a range of versions of these dependencies. If `tensorflow` installation doesn't work out-of-the-box for your particular system, you may need to refer to [the tensorflow website](https://www.tensorflow.org/install) for guidelines.
 
 To then install the latest release of `molecule_generation`, simply run
 ```bash
@@ -24,9 +24,6 @@ pip install molecule-generation
 ```
 
 Alternatively, running `pip install -e .` within the root folder installs the latest state of the code, including changes that were merged into `main` but not yet released.
-
-Note that in the instructions above we pinned the `rdkit` version, as this is the version the code has been tested with. However, our code is likely to work with other modern version of `rdkit` as well.
-Finally, if `tensorflow` installation doesn't work out-of-the-box for your particular system, you may need to refer to [the tensorflow website](https://www.tensorflow.org/install) for guidelines.
 
 A MoLeR checkpoint trained using the default hyperparameters is available [here](https://figshare.com/ndownloader/files/34642724) (or [here](https://pan.baidu.com/s/1lkiWK9-d5MvNyzqRrusGXA?pwd=4hij) if you're in China and figshare doesn't work for you). This file needs to be saved in a fresh folder `MODEL_DIR` (e.g., `/tmp/MoLeR_checkpoint`) and be renamed to have the `.pkl` ending (e.g., to `GNN_Edge_MLP_MoLeR__2022-02-24_07-16-23_best.pkl`). Then you can sample 10 molecules by running
 

--- a/molecule_generation/chem/valence_constraints.py
+++ b/molecule_generation/chem/valence_constraints.py
@@ -51,7 +51,7 @@ def constrain_edge_choices_based_on_valence(
 
     # Early exit for degenerate case:
     if len(candidate_target_nodes) == 0:
-        return np.zeros(shape=(0,), dtype=np.bool)
+        return np.zeros(shape=(0,), dtype=bool)
 
     node_idx_to_valency_map = _calculate_valency_map(adjacency_lists, node_types)
     node_idx_to_max_valency_map = _calculate_max_valency(node_types)
@@ -150,7 +150,7 @@ def _calculate_valency_map(
         A numpy array of shape (num_nodes,). The ith element of the array corresponds to the valency
         of the node whose index is i.
     """
-    node_idx_to_valency_map = np.zeros(shape=len(node_types), dtype=np.int)
+    node_idx_to_valency_map = np.zeros(shape=len(node_types), dtype=np.int32)
     for edge_type_idx, adjacency_list in enumerate(adjacency_lists):
         if len(adjacency_list) == 0:
             continue

--- a/molecule_generation/test/utils/test_valence_constraints.py
+++ b/molecule_generation/test/utils/test_valence_constraints.py
@@ -64,7 +64,7 @@ def test_constrain_edge_choices_based_on_valence_with_empty_edge_choices():
 
     # Then:
     expected_edge_choices = np.zeros(shape=(0, 2), dtype=np.int32)
-    expected_open_edges = np.zeros(shape=(0,), dtype=np.bool)
+    expected_open_edges = np.zeros(shape=(0,), dtype=bool)
     np.testing.assert_array_equal(edge_choices, expected_edge_choices)
     np.testing.assert_array_equal(target_candidate_mask, expected_open_edges)
 


### PR DESCRIPTION
In `numpy 1.24.0`, [some array types were deprecated](https://numpy.org/doc/stable/release/1.24.0-notes.html), including `np.bool` and `np.int` which appeared a few times in our code. This made `molecule_generation` no longer work with newest `numpy` (mentioned in #48). Here I'm fixing these deprecated types.