### PR TITLE
Reformat with `black==23.1.0` and pin its version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install numpy==${{ matrix.numpy }}
         python -m pip install .
-        python -m pip install black flake8 pytest
+        python -m pip install black==23.1.0 flake8 pytest
     - name: Lint with black
       run: |
         black . --check --diff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Reformatted the code with the newest `black` (version `23.1.0`) and pinned it in CI to avoid further unexpected updates ([#50](https://github.com/microsoft/molecule-generation/pull/50))
+
 ## [0.3.0] - 2022-10-18
 
 ### Added

--- a/molecule_generation/chem/molecule_dataset_utils.py
+++ b/molecule_generation/chem/molecule_dataset_utils.py
@@ -661,7 +661,6 @@ def _smiles_to_rdkit_mol(
 
         # Compute molecule-based scores with RDKit:
         if include_molecule_stats:
-
             datapoint["properties"] = {
                 "sa_score": compute_sa_score(rdkit_mol),
                 "clogp": MolLogP(rdkit_mol),

--- a/molecule_generation/chem/motif_utils.py
+++ b/molecule_generation/chem/motif_utils.py
@@ -230,7 +230,7 @@ def find_motifs_from_vocabulary(
 
     motifs_found = []
 
-    for (motif, atom_annotations) in fragments:
+    for motif, atom_annotations in fragments:
         smiles = Chem.MolToSmiles(motif)
 
         if smiles in motif_vocabulary.vocabulary:

--- a/molecule_generation/layers/moler_decoder.py
+++ b/molecule_generation/layers/moler_decoder.py
@@ -301,7 +301,6 @@ class MoLeRDecoder(tf.keras.layers.Layer):
         )
 
     def compute_metrics(self, *, batch_features, batch_labels, task_output) -> MoLeRDecoderMetrics:
-
         node_classification_loss = self.compute_node_type_selection_loss(
             node_type_logits=task_output.node_type_logits,
             node_type_multihot_labels=batch_labels["correct_node_type_choices"],
@@ -1128,7 +1127,6 @@ class MoLeRDecoder(tf.keras.layers.Layer):
         beam_size: int = 1,
         sampling_mode: DecoderSamplingMode = DecoderSamplingMode.GREEDY,
     ) -> List[MoLeRDecoderState]:
-
         """Decoding procedure for MoLeR.
 
         This method can handle generation of many graphs in parallel and implements greedy
@@ -1430,7 +1428,7 @@ class MoLeRDecoder(tf.keras.layers.Layer):
                     attachment_pick_results,
                     attachment_pick_logits,
                 ):
-                    for (attachment_point_pick, attachment_point_logprob) in attachment_point_picks:
+                    for attachment_point_pick, attachment_point_logprob in attachment_point_picks:
                         attachment_point_choice_info = None
                         if store_generation_traces:
                             attachment_point_choice_info = MoleculeGenerationAttachmentPointChoiceInfo(
@@ -1460,7 +1458,7 @@ class MoLeRDecoder(tf.keras.layers.Layer):
                 store_generation_traces=store_generation_traces,
                 sampling_mode=sampling_mode,
             )
-            for (decoder_state, (bond_picks, edge_choice_info)) in zip(
+            for decoder_state, (bond_picks, edge_choice_info) in zip(
                 require_bond_states, bond_pick_results
             ):
                 if len(bond_picks) == 0:
@@ -1476,7 +1474,7 @@ class MoLeRDecoder(tf.keras.layers.Layer):
                     )
                     continue
 
-                for (bond_pick, bond_pick_logprob) in bond_picks:
+                for bond_pick, bond_pick_logprob in bond_picks:
                     # If the decoder says we need no more bonds for the current focus node,
                     # we mark this and put the decoder state back for the next expansion round:
                     if bond_pick is None:

--- a/molecule_generation/models/cgvae.py
+++ b/molecule_generation/models/cgvae.py
@@ -631,7 +631,6 @@ class CGVAE(GraphTaskModel):
         max_num_steps: Optional[int] = None,  # Run until dataset ends if None
         aml_run: Optional = None,
     ) -> Tuple[float, float, List[Any]]:
-
         with EpochMetricsLogger(
             window_size=self._logged_loss_smoothing_window_size,
             quiet=quiet,

--- a/molecule_generation/models/moler_base_model.py
+++ b/molecule_generation/models/moler_base_model.py
@@ -175,7 +175,6 @@ class MoLeRBaseModel(GraphTaskModel):
     def _compute_decoder_loss_and_metrics(
         self, batch_features, task_output, batch_labels
     ) -> Tuple[tf.Tensor, MoLeRDecoderMetrics]:
-
         decoder_metrics = self.decoder.compute_metrics(
             batch_features=batch_features, batch_labels=batch_labels, task_output=task_output
         )
@@ -200,7 +199,6 @@ class MoLeRBaseModel(GraphTaskModel):
     def _get_decoder_output(
         self, *, batch_features, molecule_representations, training
     ) -> MoLeRDecoderOutput:
-
         partial_adjacency_lists: Tuple[tf.Tensor, ...] = tuple(
             batch_features[f"partial_adjacency_list_{edge_type_idx}"]
             for edge_type_idx in range(self._num_edge_types)

--- a/molecule_generation/models/moler_generator.py
+++ b/molecule_generation/models/moler_generator.py
@@ -31,7 +31,6 @@ class MoLeRGenerator(MoLeRBaseModel):
         ],  # Ignored: here for consistency of interface with moler_vae
         training: bool,
     ) -> MoLeRGeneratorOutput:
-
         molecule_representations = tf.zeros(
             (batch_features["num_partial_graphs_in_batch"], self.latent_dim)
         )
@@ -83,7 +82,6 @@ class MoLeRGenerator(MoLeRBaseModel):
         self.built = True
 
     def compute_epoch_metrics(self, task_results: List[Any]) -> Tuple[float, str]:
-
         average_loss = self._dict_average(task_results, "loss")
         result_string = f"\n" f"Avg weighted sum. of graph losses: {average_loss: 7.4f}\n"
 

--- a/molecule_generation/models/moler_vae.py
+++ b/molecule_generation/models/moler_vae.py
@@ -154,7 +154,6 @@ class MoLeRVae(MoLeRBaseModel):
                 raise ValueError(f"Unknown property type {prop_type}")
 
     def build(self, input_shapes: Dict[str, Any]):
-
         # Build decoder
         super().build(input_shapes=input_shapes)
 
@@ -413,7 +412,6 @@ class MoLeRVae(MoLeRBaseModel):
         task_output: MoLeRVaeOutput,
         batch_labels: Dict[str, tf.Tensor],
     ) -> MoLeRMetrics:
-
         total_loss, decoder_metrics = self._compute_decoder_loss_and_metrics(
             batch_features=batch_features, task_output=task_output, batch_labels=batch_labels
         )
@@ -475,7 +473,6 @@ class MoLeRVae(MoLeRBaseModel):
         return graph_generation_losses
 
     def compute_epoch_metrics(self, task_results: List[Any]) -> Tuple[float, str]:
-
         # Compute results for the individual property predictors.
         # Weigh their respective contributions using the loss weight.
         prop_to_task_results: Dict[str, List[Dict[str, Any]]] = {

--- a/molecule_generation/utils/decoder_batching.py
+++ b/molecule_generation/utils/decoder_batching.py
@@ -22,7 +22,6 @@ def batch_decoder_states(
     init_batch_callback: Callable[[Dict[str, Any]], None],
     add_state_to_batch_callback: Callable[[Dict[str, Any], MoLeRDecoderState], None],
 ) -> Generator[Tuple[Dict[str, Any], List[MoLeRDecoderState]], None, None]:
-
     graph_id_offset = 0
 
     def _get_empty_batch() -> Dict[str, Any]:

--- a/molecule_generation/utils/epoch_metrics_logger.py
+++ b/molecule_generation/utils/epoch_metrics_logger.py
@@ -12,7 +12,6 @@ class EpochMetricsLogger:
     def __init__(
         self, *, window_size: int = 100, quiet: bool, aml_run: Optional, training: bool
     ) -> None:
-
         self._window_size = window_size
         self._quiet = quiet
         self._aml_run = aml_run

--- a/molecule_generation/utils/moler_inference_server.py
+++ b/molecule_generation/utils/moler_inference_server.py
@@ -62,7 +62,7 @@ def _encode_from_smiles(
         )
 
         # Get means and log variances, both with shape [NumGraphsInBatch, LatentDim].
-        (graph_rep_mean, graph_rep_logvar, _,) = model.compute_latent_molecule_representations(
+        (graph_rep_mean, graph_rep_logvar, _) = model.compute_latent_molecule_representations(
             final_node_representations=final_node_representations,
             num_graphs=batch_features["num_graphs_in_batch"],
             node_to_graph_map=batch_features["node_to_graph_map"],

--- a/molecule_generation/utils/moler_visualisation_utils.py
+++ b/molecule_generation/utils/moler_visualisation_utils.py
@@ -279,7 +279,6 @@ class GraphGenerationVisualiser(ABC):
                 )
 
     def visualise_from_samples(self, molecule_representation: np.ndarray):
-
         property_data: Dict[str, PropertyPredictionInformation] = {}
 
         for prop_name in self.supported_property_names:


### PR DESCRIPTION
A recent CI failure on #49 highlighted the fact that the new `black` version `23.*` introduces some formatting changes with respect to `22.*`. Since the changes are relatively minor, I apply them here, but also pin `black` in CI to avoid such unexpected CI failures in the future.