### PR TITLE
Expose generation steps in VaeWrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Option for `decode` to return the entire generation trace ([#51](https://github.com/microsoft/molecule-generation/pull/51))
+
 ### Changed
 - Reformatted the code with the newest `black` (version `23.1.0`) and pinned it in CI to avoid further unexpected updates ([#50](https://github.com/microsoft/molecule-generation/pull/50))
 

--- a/molecule_generation/test/integration/test_data_moler_integration.py
+++ b/molecule_generation/test/integration/test_data_moler_integration.py
@@ -336,7 +336,7 @@ def test_can_decode_smiles_with_trained_model(capsys, tmp_test_directory):
 
     with MoLeRInferenceServer(get_model_path(tmp_test_directory)) as moler:
         embedding = moler.encode([caffeine_smiles])
-        smiles = [s for s, _ in moler.decode(embedding)]
+        smiles = [s for s, _, _ in moler.decode(embedding)]
 
     assert len(smiles) == 1
 
@@ -353,7 +353,7 @@ def test_can_decode_smiles_with_scaffold_trained_model(capsys, tmp_test_director
     with MoLeRInferenceServer(get_model_path(tmp_test_directory)) as moler:
         # Initial Molecules = [Scaffold]
         embedding = moler.encode([base_smiles])
-        smiles = [s for s, _ in moler.decode(embedding, init_mols=[scaffold_mol])]
+        smiles = [s for s, _, _ in moler.decode(embedding, init_mols=[scaffold_mol])]
 
     assert len(smiles) == 1
 
@@ -376,7 +376,7 @@ def test_can_decode_smiles_list_with_optional_scaffold_trained_model(capsys, tmp
     with MoLeRInferenceServer(get_model_path(tmp_test_directory)) as moler:
         # Initial Molecules = [Scaffold, None]
         embeddings = moler.encode([base_smiles, base_smiles])
-        smiles = [s for s, _ in moler.decode(embeddings, init_mols=[scaffold_mol, None])]
+        smiles = [s for s, _, _ in moler.decode(embeddings, init_mols=[scaffold_mol, None])]
 
         assert len(smiles) == 2
 
@@ -385,12 +385,12 @@ def test_can_decode_smiles_list_with_optional_scaffold_trained_model(capsys, tmp
 
         # Initial Molecules = [None, None]
         embeddings = moler.encode([base_smiles, base_smiles])
-        smiles = [s for s, _ in moler.decode(embeddings, init_mols=[None, None])]
+        smiles = [s for s, _, _ in moler.decode(embeddings, init_mols=[None, None])]
 
         assert len(smiles) == 2
 
         # Initial Molecules = None
         embeddings = moler.encode([base_smiles, base_smiles])
-        smiles = [s for s, _ in moler.decode(embeddings)]
+        smiles = [s for s, _, _ in moler.decode(embeddings)]
 
         assert len(smiles) == 2

--- a/molecule_generation/utils/moler_inference_server.py
+++ b/molecule_generation/utils/moler_inference_server.py
@@ -117,6 +117,11 @@ def _decode_from_latents(
         if include_generation_steps:
             generation_steps = best_decoder_state.generation_steps
 
+            # Before returning, we slightly clean up the molecules in the trace. In particular, this
+            # fixes implicit hydrogen count for the partial molecules.
+            for step in generation_steps:
+                Chem.SanitizeMol(step.molecule)
+
         yield (
             Chem.MolToSmiles(mol, isomericSmiles=False),
             input_mol_representation,


### PR DESCRIPTION
For downstream analysis, it is often useful to be able to look at the entire generation trace of decoded molecules. In this PR, I'm extending the high-level model interface to (optionally) expose this information.