### PR TITLE
Turn off parallel data loading in tests

### DIFF
--- a/molecule_generation/test/models/test_gnn_vae.py
+++ b/molecule_generation/test/models/test_gnn_vae.py
@@ -27,7 +27,7 @@ def dataset():
             "max_partial_nodes_per_batch": 50,
         }
     )
-    dataset = JSONLCGVAETraceDataset(dataset_params)
+    dataset = JSONLCGVAETraceDataset(dataset_params, no_parallelism=True)
     data_path = RichPath.create(
         os.path.join(os.path.dirname(__file__), "..", "test_datasets", "cgvae_traces")
     )

--- a/molecule_generation/test/models/test_moler_vae.py
+++ b/molecule_generation/test/models/test_moler_vae.py
@@ -28,7 +28,7 @@ def dataset():
             "max_partial_nodes_per_batch": 50,
         }
     )
-    dataset = JSONLMoLeRTraceDataset(dataset_params)
+    dataset = JSONLMoLeRTraceDataset(dataset_params, no_parallelism=True)
     data_path = RichPath.create(
         os.path.join(os.path.dirname(__file__), "..", "test_datasets", "moler_traces")
     )


### PR DESCRIPTION
Our CI pipeline hangs occasionally when running the more end-to-end model tests. This seems to be caused by the use of multiprocessing during data loading (which doesn't work too well in combination with `pytest`). In this PR, I turn off parallel data loading in these tests, in hope that this will make the CI more stable.