### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.4.0] - 2023-06-16
+
 ### Added
 - Add an option for `decode` to return the entire generation trace ([#51](https://github.com/microsoft/molecule-generation/pull/51))
 
@@ -55,7 +57,8 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 - Add full implementation of MoLeR as introduced in the paper
 - Add reference implementation of CGVAE, not yet supported by the high-level model API
 
-[Unreleased]: https://github.com/microsoft/molecule-generation/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/microsoft/molecule-generation/compare/v0.4.0...HEAD
 [0.1.0]: https://github.com/microsoft/molecule-generation/releases/tag/v0.1.0
 [0.2.0]: https://github.com/microsoft/molecule-generation/releases/tag/v0.2.0
 [0.3.0]: https://github.com/microsoft/molecule-generation/releases/tag/v0.3.0
+[0.4.0]: https://github.com/microsoft/molecule-generation/releases/tag/v0.4.0


### PR DESCRIPTION
This PR edits the CHANGELOG to mark the v0.4.0 release. After it's merged, I will tag the resulting commit, and then push the release to PyPI.

In particular, this release includes several changes that make `molecule_generation` compatible with the latest versions of `rdkit` and `numpy`.