### PR TITLE
Expand README and relax protobuf version requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Relax `protobuf` version requirement ([#62](https://github.com/microsoft/molecule-generation/pull/62))
+
 ## [0.4.0] - 2023-06-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ See below for how to train your own model and run more advanced inference.
 >
 > A: Please submit an issue and default to using one of the pinned configurations from `environment-py*.yml` in the meantime.
 
-> Q: Installing `tensorflow` on my system does not work.
+> Q: Installing `tensorflow` on my system does not work, or it works but GPU is not being used.
 >
-> A: Please refer to [the tensorflow website](https://www.tensorflow.org/install) for guidelines.
+> A: Please refer to [the tensorflow website](https://www.tensorflow.org/install) for guidelines. In particular, with recent versions of `tensorflow` one may get a "libdevice not found" error; in that case please follow the instructions at the bottom of [this page](https://www.tensorflow.org/install/pip#step-by-step_instructions).
 
 ## Workflow
 

--- a/README.md
+++ b/README.md
@@ -36,17 +36,17 @@ See below for how to train your own model and run more advanced inference.
 
 ### Troubleshooting
 
-> Q: I am in China and so the figshare checkpoint link does not work for me.
+> Q: Installing `tensorflow` on my system does not work, or it works but GPU is not being used.
 >
-> A: You can try [this link](https://pan.baidu.com/s/1lkiWK9-d5MvNyzqRrusGXA?pwd=4hij) instead.
+> A: Please refer to [the tensorflow website](https://www.tensorflow.org/install) for guidelines. In particular, with recent versions of `tensorflow` one may get a "libdevice not found" error; in that case please follow the instructions at the bottom of [this page](https://www.tensorflow.org/install/pip#step-by-step_instructions).
 
 > Q: My particular combination of dependency versions does not work.
 >
 > A: Please submit an issue and default to using one of the pinned configurations from `environment-py*.yml` in the meantime.
 
-> Q: Installing `tensorflow` on my system does not work, or it works but GPU is not being used.
+> Q: I am in China and so the figshare checkpoint link does not work for me.
 >
-> A: Please refer to [the tensorflow website](https://www.tensorflow.org/install) for guidelines. In particular, with recent versions of `tensorflow` one may get a "libdevice not found" error; in that case please follow the instructions at the bottom of [this page](https://www.tensorflow.org/install/pip#step-by-step_instructions).
+> A: You can try [this link](https://pan.baidu.com/s/1lkiWK9-d5MvNyzqRrusGXA?pwd=4hij) instead.
 
 ## Workflow
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setuptools.setup(
         "dpu-utils>=0.2.13",
         "more-itertools",
         "numpy>=1.19.2",
-        "protobuf>=3.20,<4",  # Avoid the breaking 4.21.0 release.
+        "protobuf<4.21",  # Avoid the breaking 4.21.0 release.
         "scikit-learn>=0.24.1",
         "tensorflow>=2.1.0,<3",
         "tf2_gnn>=2.13.0",


### PR DESCRIPTION
This PR expands on the Tensorflow troubleshooting section in `README.md`, taking into account how installing the newest versions on Ubuntu 22.04 requires extra care (fixes #61). On top of this, I also relaxed the pin on `protobuf` version in `setup.py`; I'm not sure why the lower bound was introduced, but some of the `tensorflow` versions actually conflict with it.