### PR TITLE
Stop running CI under Python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - environment-file: environment-py37.yml
-            build-name: "python 3.7.7, tf 2.1.0, rdkit 2020.09.1"
           - environment-file: environment-py38.yml
             build-name: "python 3.8.16, tf 2.6.2, rdkit 2021.09.1"
           - environment-file: environment-py39.yml


### PR DESCRIPTION
The Python 3.7 CI has been problematic for a while now, as the integration tests tend to crash for unclear reasons. Given that this does not appear under 3.8, 3.9 or 3.10, and that 3.7 is now past it's end-of-life, in this PR I drop the 3.7 CI.