### PR TITLE
Fix hydrogen handling in scaffolds with explicit attachment points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 - Relax `protobuf` version requirement ([#62](https://github.com/microsoft/molecule-generation/pull/62))
 
 ### Fixed
+- Fix hydrogen handling in scaffolds with explicit attachment points ([#70](https://github.com/microsoft/molecule-generation/pull/70))
 - Avoid memory leaks and other `tensorflow` issues ([#68](https://github.com/microsoft/molecule-generation/pull/68))
 
 ## [0.4.0] - 2023-06-16


### PR DESCRIPTION
When a scaffold is provided during decoding, we assume the model is free to attach further atoms to any atom in the scaffold, unless it contains explicit attachment points, in which case we only allow attaching to those atoms. However, the handling of these attachment points had a bug regarding explicit hydrogens, which would cause the scaffold molecule to be malformed and decoding to fail. This PR fixes this issue by carefully updating the hydrogen count where appropriate.