### PR TITLE
Release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.4.1] - 2024-01-03
+
 ### Changed
 - Relax `protobuf` version requirement ([#62](https://github.com/microsoft/molecule-generation/pull/62))
 
@@ -64,8 +66,9 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 - Add full implementation of MoLeR as introduced in the paper
 - Add reference implementation of CGVAE, not yet supported by the high-level model API
 
-[Unreleased]: https://github.com/microsoft/molecule-generation/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/microsoft/molecule-generation/compare/v0.4.1...HEAD
 [0.1.0]: https://github.com/microsoft/molecule-generation/releases/tag/v0.1.0
 [0.2.0]: https://github.com/microsoft/molecule-generation/releases/tag/v0.2.0
 [0.3.0]: https://github.com/microsoft/molecule-generation/releases/tag/v0.3.0
 [0.4.0]: https://github.com/microsoft/molecule-generation/releases/tag/v0.4.0
+[0.4.1]: https://github.com/microsoft/molecule-generation/releases/tag/v0.4.1


### PR DESCRIPTION
This PR edits the CHANGELOG to mark the v0.4.1 release, which contains bug fixes and small changes to dependency constraints. After it's merged, I will tag the resulting commit, and then push the release to PyPI.